### PR TITLE
Corrected and remove PLATFORM_SCHEMA

### DIFF
--- a/sector_alarm.py
+++ b/sector_alarm.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 
 import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 from homeassistant.helpers.aiohttp_client import async_get_clientsession


### PR DESCRIPTION
PLATFORM_SCHEMA initialisation caused configuration checker to look for - platform: definition in configuration.yaml thus causing the component to fail to load (when restarting homeassistant only) a full host reboot would actually work. Verified in hass.io 0.75.2.

Now i can finally sleep again.