### PR TITLE
WIP: Autoversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,6 @@ sector_alarm:
   version: <version of the sector alarm api, default is 'v1_1_70'>
 ```
 
+***Experimental*** *set version to 'auto' for autodetect*
+
 Skip optional lines completely if not wanted.

--- a/sector_alarm/__init__.py
+++ b/sector_alarm/__init__.py
@@ -53,7 +53,7 @@ async def async_setup(hass, config):
 
     session = async_get_clientsession(hass)
 
-    async_sector = AsyncSector(
+    async_sector = await AsyncSector.create(
         session,
         config[DOMAIN].get(CONF_ALARM_ID),
         config[DOMAIN].get(CONF_EMAIL),


### PR DESCRIPTION
Together with mgejke/asyncsector#14 this will allow for setting version to 'auto' in config, and will then fetch the version code for use in the API requests.

Currently does this check during (every) init. Maybe we should do a single fetch (AsyncSector.getapiversion)  and store as a state, or some kind of variable, and only do another fetch when an update fails with INVALID VERSION...

Also I believe the first commit, the async init, does not break the current functioninality, but this might need some more testing...

Some discussion in #23 and mgejke/asyncsector#12

Oh, and until mgejke/asyncsector#14 gets merged, i do testing in loial/hass-sectoralarm@feature-autoversion-test (changing asyncsector requirement to 'https://github.com/loial/asyncsector/archive/feature-autoversion.zip#asyncsector==0.2.0' )